### PR TITLE
feat: `defer.schedule(fn, frequencyStr)`

### DIFF
--- a/.changeset/purple-dogs-dream.md
+++ b/.changeset/purple-dogs-dream.md
@@ -3,3 +3,27 @@
 ---
 
 Introduce `defer.schedule(fn, frequencyStr)`
+
+Defer now support scheduled functions (CRON), as follows:
+
+```ts
+import { defer } from '@defer.run/client'
+
+async function myDeferWorkflow() {
+  const users = await prisma.user.find({
+    where: {
+      // ...
+    },
+  })
+
+  // do something...
+}
+
+defer.schedule(myDeferWorkflow, 'every day at 10am')
+```
+
+**Notes**
+
+- a scheduled function should not take arguments
+- a scheduled function is scheduled on PST time (beta)
+- a scheduled function should not be invoked (will result in errors)

--- a/.changeset/purple-dogs-dream.md
+++ b/.changeset/purple-dogs-dream.md
@@ -19,7 +19,7 @@ async function myDeferWorkflow() {
   // do something...
 }
 
-defer.schedule(myDeferWorkflow, 'every day at 10am')
+export default defer.schedule(myDeferWorkflow, 'every day at 10am')
 ```
 
 **Notes**

--- a/.changeset/purple-dogs-dream.md
+++ b/.changeset/purple-dogs-dream.md
@@ -1,0 +1,5 @@
+---
+"@defer.run/client": minor
+---
+
+Introduce `defer.schedule(fn, frequencyStr)`

--- a/.changeset/purple-dogs-dream.md
+++ b/.changeset/purple-dogs-dream.md
@@ -25,5 +25,5 @@ export default defer.schedule(myDeferWorkflow, 'every day at 10am')
 **Notes**
 
 - a scheduled function should not take arguments
-- a scheduled function is scheduled on PST time (beta)
+- a scheduled function is **scheduled on UTC time**
 - a scheduled function should not be invoked (will result in errors)

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "author": "Charly POLY <cpoly55@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@darkeyedevelopers/natural-cron.js": "^1.1.0",
     "@whatwg-node/fetch": "^0.2.9",
-    "friendly-cron": "^0.0.2",
     "parse-duration": "^1.0.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@whatwg-node/fetch": "^0.2.9",
+    "friendly-cron": "^0.0.2",
     "parse-duration": "^1.0.2"
   },
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,4 +2,4 @@ export const DOMAIN = "https://api.defer.run";
 export const PATH = "/api/v1/";
 export const TOKEN_ENV_NAME = "DEFER_TOKEN";
 export const FN_EXECUTION_POLLING_INTERVAL_SECS = 2;
-export const INTERNAL_VERSION = 2;
+export const INTERNAL_VERSION = 3;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Units } from "parse-duration";
+// @ts-expect-error no types def
+import friendlyCron from "friendly-cron";
 import { DOMAIN, INTERNAL_VERSION, PATH, TOKEN_ENV_NAME } from "./constants.js";
 import {
   DeferExecuteResponse,
@@ -42,14 +44,25 @@ export type DeferRetFnParameters<
   F extends (...args: any | undefined) => Promise<any>
 > = [...first: Parameters<F>, options: DeferExecutionOptions];
 
+export interface HasDeferMetadata {
+  __metadata: {
+    version: number;
+    cron?: string;
+  };
+}
+
 export interface DeferRetFn<
   F extends (...args: any | undefined) => Promise<any>
-> {
+> extends HasDeferMetadata {
   (...args: Parameters<F>): ReturnType<F>;
   __fn: F;
-  __version: number;
   await: DeferAwaitRetFn<F>;
   delayed: (...args: DeferRetFnParameters<F>) => ReturnType<F>;
+}
+export interface DeferScheduledFn<F extends (...args: never) => Promise<any>>
+  extends HasDeferMetadata {
+  (...args: Parameters<F>): void;
+  __fn: F;
 }
 export interface DeferAwaitRetFn<
   F extends (...args: any | undefined) => Promise<any>
@@ -59,6 +72,10 @@ export interface DeferAwaitRetFn<
 
 export interface Defer {
   <F extends (...args: any | undefined) => Promise<any>>(fn: F): DeferRetFn<F>;
+  schedule: <F extends (args: never[]) => Promise<any>>(
+    fn: F,
+    schedule: string
+  ) => DeferScheduledFn<F>;
 }
 
 export const isDeferExecution = (obj: any): obj is DeferExecuteResponse =>
@@ -82,7 +99,7 @@ export const defer: Defer = (fn) => {
     }
   };
   ret.__fn = fn;
-  ret.__version = INTERNAL_VERSION;
+  ret.__metadata = { version: INTERNAL_VERSION };
   ret.await = async (...args) => {
     const executionResult = (await defer(fn)(...args)) as UnPromise<
       ReturnType<typeof fn>
@@ -121,13 +138,27 @@ export const defer: Defer = (fn) => {
   return ret as any;
 };
 
+defer.schedule = (fn, schedule) => {
+  const ret: DeferScheduledFn<typeof fn> = () => {
+    throw new Error("`defer.scheduled()` functions should not be invoked.");
+  };
+
+  ret.__fn = fn;
+  ret.__metadata = {
+    version: INTERNAL_VERSION,
+    cron: friendlyCron(schedule) || schedule,
+  };
+
+  return ret;
+};
+
 // EXAMPLES:
-//
+
 // interface Contact {
 //   id: string;
 //   name: string;
 // }
-//
+
 // const importContacts = (companyId: string, contacts: Contact[]) => {
 //   return new Promise<{ imported: number; companyId: string }>((resolve) => {
 //     console.log(`Start importing contacts for company#${companyId}`);
@@ -138,13 +169,19 @@ export const defer: Defer = (fn) => {
 //     }, 5000);
 //   });
 // };
-//
+
+// async function myFunction() {
+//   return 1;
+// }
+
+// defer.schedule(myFunction, "every day");
+
 // const importContactsD = defer(importContacts);
-//
+
 // async function test() {
 //   await importContactsD("1", []); // fire and forget
-//
+
 //   await importContactsD.await("1", []); // wait for execution result
-//
+
 //   await importContactsD.delayed("1", [], { delay: "2 days" }); // scheduled
 // }

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,13 +143,10 @@ defer.schedule = (fn, schedule) => {
     throw new Error("`defer.scheduled()` functions should not be invoked.");
   };
 
-  const cronTab = getCronString(schedule) as string;
-
   ret.__fn = fn;
   ret.__metadata = {
     version: INTERNAL_VERSION,
-    // remove seconds from crontab (not supported)
-    cron: cronTab ? cronTab.split(" ").splice(1).join(" ") : schedule,
+    cron: getCronString(schedule) as string,
   };
 
   return ret;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Units } from "parse-duration";
-// @ts-expect-error no types def
-import friendlyCron from "friendly-cron";
+// @ts-expect-error untyped dep
+import getCronString from "@darkeyedevelopers/natural-cron.js";
 import { DOMAIN, INTERNAL_VERSION, PATH, TOKEN_ENV_NAME } from "./constants.js";
 import {
   DeferExecuteResponse,
@@ -143,7 +143,7 @@ defer.schedule = (fn, schedule) => {
     throw new Error("`defer.scheduled()` functions should not be invoked.");
   };
 
-  const cronTab = friendlyCron(schedule) as string;
+  const cronTab = getCronString(schedule) as string;
 
   ret.__fn = fn;
   ret.__metadata = {
@@ -173,11 +173,11 @@ defer.schedule = (fn, schedule) => {
 //   });
 // };
 
-// async function myFunction() {
-//   return 1;
-// }
+async function myFunction() {
+  return 1;
+}
 
-// defer.schedule(myFunction, "every day");
+defer.schedule(myFunction, "every day");
 
 // const importContactsD = defer(importContacts);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,10 +143,13 @@ defer.schedule = (fn, schedule) => {
     throw new Error("`defer.scheduled()` functions should not be invoked.");
   };
 
+  const cronTab = friendlyCron(schedule) as string;
+
   ret.__fn = fn;
   ret.__metadata = {
     version: INTERNAL_VERSION,
-    cron: friendlyCron(schedule) || schedule,
+    // remove seconds from crontab (not supported)
+    cron: cronTab ? cronTab.split(" ").splice(1).join(" ") : schedule,
   };
 
   return ret;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2413,6 +2413,11 @@ formdata-node@^4.3.1:
     node-domexception "1.0.0"
     web-streams-polyfill "4.0.0-beta.1"
 
+friendly-cron@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/friendly-cron/-/friendly-cron-0.0.2.tgz#02f72b8c44c62b55f8e898a01c0b6c23cbadbabc"
+  integrity sha512-/vVd2jS0LHTryOIIwaWZruRaBBBPdiliZTExlfKnNn35YxnA5Y4wa6EuZIpbiNiSwwBvuLoWz4Ir5WWu5XfgXQ==
+
 fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,6 +537,11 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@darkeyedevelopers/natural-cron.js@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@darkeyedevelopers/natural-cron.js/-/natural-cron.js-1.1.0.tgz#d77721f6ea5912d9d114db6b0dbe6aa26eb7b235"
+  integrity sha512-CBRydMA7ExsLF6Ukmhf5QeUcv64RVfS417MqRZhN97hle1bDTJuT91AwO1K7gez/41uLSH6We07TqNp/XeLryA==
+
 "@esbuild/linux-loong64@0.14.54":
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz#de2a4be678bd4d0d1ffbb86e6de779cde5999028"
@@ -2412,11 +2417,6 @@ formdata-node@^4.3.1:
   dependencies:
     node-domexception "1.0.0"
     web-streams-polyfill "4.0.0-beta.1"
-
-friendly-cron@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/friendly-cron/-/friendly-cron-0.0.2.tgz#02f72b8c44c62b55f8e898a01c0b6c23cbadbabc"
-  integrity sha512-/vVd2jS0LHTryOIIwaWZruRaBBBPdiliZTExlfKnNn35YxnA5Y4wa6EuZIpbiNiSwwBvuLoWz4Ir5WWu5XfgXQ==
 
 fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
Introduces `defer.schedule(fn, frequencyStr)`

Defer now support scheduled functions (CRON), as follows:

```ts
import { defer } from '@defer.run/client'

async function myDeferWorkflow() {
  const users = await prisma.user.find({
    where: {
      // ...
    },
  })

  // do something...
}

export default defer.schedule(myDeferWorkflow, 'every day at 10am')
```

**Notes**

- a scheduled function should not take arguments
- a scheduled function is **scheduled on UTC time**
- a scheduled function should not be invoked (will result in errors)
