### PR TITLE
feat: `delay()` api

### DIFF
--- a/.changeset/clever-cheetahs-compete.md
+++ b/.changeset/clever-cheetahs-compete.md
@@ -1,0 +1,15 @@
+---
+"@defer.run/client": minor
+---
+
+Introduce a new API to delay an execution:
+
+```ts
+import { delay } from "@defer.run/client"
+import { helloWorld } from '../defer/helloWorld';
+
+// create a delayed execution
+const delayedHelloWorld = delay(helloWorld, '1h')
+
+delayedHelloWorld() // background execution in 1 hour
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,9 @@ export interface DeferRetFn<
   (...args: Parameters<F>): ReturnType<F>;
   __fn: F;
   await: DeferAwaitRetFn<F>;
+  /**
+   * @deprecated use `delay(deferFn)` instead
+   */
   delayed: (...args: DeferRetFnParameters<F>) => ReturnType<F>;
 }
 export interface DeferScheduledFn<F extends (...args: never) => Promise<any>>
@@ -170,13 +173,13 @@ defer.schedule = (fn, schedule) => {
 //   });
 // };
 
-async function myFunction() {
-  return 1;
-}
-
-defer.schedule(myFunction, "every day");
-
 // const importContactsD = defer(importContacts);
+
+// async function myFunction() {
+//   return 1;
+// }
+
+// defer.schedule(myFunction, "every day");
 
 // async function test() {
 //   await importContactsD("1", []); // fire and forget
@@ -185,3 +188,38 @@ defer.schedule(myFunction, "every day");
 
 //   await importContactsD.delayed("1", [], { delay: "2 days" }); // scheduled
 // }
+
+/**
+ * Delay the execution of a background function
+ * @constructor
+ * @param {Function} deferFn - A background function (`defer(...)` result)
+ * @param {string|Date} delay - The delay (ex: "1h" or a Date object)
+ * @returns Function
+ */
+export const delay =
+  <F extends (...args: any | undefined) => Promise<any>>(
+    deferFn: DeferRetFn<F>,
+    delay: DelayString | Date
+  ): (() => F) =>
+  (...args) => {
+    const fn = deferFn.__fn;
+    if (debug) {
+      console.log(`[defer.run][${fn.name}] invoked.`);
+    }
+    if (token && fetcher) {
+      return executeBackgroundFunction(fn.name, args, fetcher, debug, {
+        delay,
+      });
+    } else {
+      if (debug) {
+        console.log(`[defer.run][${fn.name}] defer ignore, no token found.`);
+      }
+      // try to serialize arguments for develpment warning purposes
+      serializeBackgroundFunctionArguments(fn.name, args);
+      // FIX: do better
+      return fn(...(args as any)) as any;
+    }
+  };
+
+// const delayed = delay(importContactsD, '1h')
+// delayed()

--- a/tests/delay.spec.ts
+++ b/tests/delay.spec.ts
@@ -1,0 +1,53 @@
+import { Response } from "@whatwg-node/fetch";
+import { defer, delay, init } from "../src";
+import type { DeferExecuteResponse } from "../src/execute";
+import { DeferConfiguredFetcher, makeFetcher } from "../src/fetcher";
+
+
+jest.mock("../src/fetcher")
+
+describe("delay()", () => {
+  describe("when Defer is active (`DEFER_TOKEN` is set)", () => {
+
+    describe('with successful API responses', () => {
+      let fetcher: DeferConfiguredFetcher | undefined;
+      beforeAll(() => {
+        fetcher = jest.fn().mockImplementationOnce(async () => {
+          return new Response(JSON.stringify({ id: '1' } as DeferExecuteResponse))
+        })
+        jest.mocked(makeFetcher).mockImplementationOnce(() => fetcher!)
+        init({ apiToken: "test" });
+      });
+
+      it("should throw if arguments are not serializable", async () => {
+        const myFunction = jest.fn(async function testFn(_str: bigint) {});
+        const deferred = defer(myFunction);
+        const delayed = delay(deferred, '1h')
+        const consoleSpy = jest
+          .spyOn(console, "log")
+          .mockImplementation(() => {});
+  
+        await expect(delayed(2n)).rejects.toThrow(
+          "[defer.run][mockConstructor] failed to serialize arguments"
+        );
+  
+        expect(myFunction).not.toHaveBeenCalled();
+        expect(consoleSpy).toBeCalledWith(
+          "[defer.run][mockConstructor] Failed to serialize arguments: TypeError: Do not know how to serialize a BigInt"
+        );
+      });
+
+      it("should NOT call the wrapped function and return execution ID", async () => {
+        const myFunction = jest.fn(async (_str: string) => {});
+        const deferred = defer(myFunction);
+        const delayed = delay(deferred, new Date('2023-01-01'))
+  
+        const result = await delayed("")
+        expect(result).toEqual({ id: '1', __deferExecutionResponse: true })
+        expect(myFunction).not.toHaveBeenCalled();
+        expect(fetcher).toHaveBeenCalledWith("enqueue", {"body": "{\"name\":\"mockConstructor\",\"arguments\":[\"\"],\"schedule_for\":\"2023-01-01T00:00:00.000Z\"}", "method": "POST"})
+      });
+
+    })
+  })
+});


### PR DESCRIPTION
Introduce a new API to delay an execution:

```ts
import { delay } from "@defer.run/client"
import { helloWorld } from '../defer/helloWorld';

// create a delayed execution
const delayedHelloWorld = delay(helloWorld, '1h')

delayedHelloWorld() // background execution in 1 hour
```

----

- [x] QA
- [x] fix typings
- [x] add tests