### PR TITLE
Add metadatas execution option capability

### DIFF
--- a/.changeset/tasty-eyes-study.md
+++ b/.changeset/tasty-eyes-study.md
@@ -1,0 +1,5 @@
+---
+"@defer/client": minor
+---
+
+Add support for execution metadata

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,11 +1,17 @@
 import type { HTTPClient } from "./httpClient.js";
 import { jitter } from "./jitter.js";
 
+interface Metadata {
+  key: string;
+  value: string;
+}
+
 export interface EnqueueExecutionRequest {
   name: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   arguments: any[];
   scheduleFor: Date;
+  metadatas: Metadata[]
 }
 
 export interface EnqueueExecutionResponse {
@@ -37,6 +43,7 @@ export function enqueueExecution(
     name: request.name,
     arguments: request.arguments,
     schedule_for: request.scheduleFor,
+    metadatas: request.metadatas,
   });
   return client<EnqueueExecutionResponse>("POST", "/api/v1/enqueue", data);
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,17 +1,13 @@
 import type { HTTPClient } from "./httpClient.js";
+import type { Metadata } from "./index.js";
 import { jitter } from "./jitter.js";
-
-interface Metadata {
-  key: string;
-  value: string;
-}
 
 export interface EnqueueExecutionRequest {
   name: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   arguments: any[];
   scheduleFor: Date;
-  metadatas: Metadata[]
+  metadata: Metadata;
 }
 
 export interface EnqueueExecutionResponse {
@@ -43,7 +39,7 @@ export function enqueueExecution(
     name: request.name,
     arguments: request.arguments,
     schedule_for: request.scheduleFor,
-    metadatas: request.metadatas,
+    metadata: request.metadata,
   });
   return client<EnqueueExecutionResponse>("POST", "/api/v1/enqueue", data);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ interface DeferDelay {
   <F extends (...args: any | undefined) => Promise<any>>(
     deferFn: DeferRetFn<F>,
     delay: DelayString | Date
-  ): (...args: Parameters<F>) => Promise<EnqueueExecutionResponse>;
+  ): DeferRetFn<F>;
 }
 
 /**
@@ -281,6 +281,8 @@ export const delay: DeferDelay = (deferFn, delay) => {
     return { id };
   };
 
+  delayedDeferFn.__fn = deferFn.__fn;
+  delayedDeferFn.__metadata = deferFn.__metadata;
   delayedDeferFn.__execOptions = {
     ...deferFn.__execOptions,
     delay,
@@ -293,7 +295,7 @@ interface DeferAddMetadata {
   <F extends (...args: any | undefined) => Promise<any>>(
     deferFn: DeferRetFn<F>,
     metadatas: Metadata[]
-  ): (...args: Parameters<F>) => Promise<EnqueueExecutionResponse>;
+  ): DeferRetFn<F>;
 }
 
 /**
@@ -347,6 +349,8 @@ export const addMetadata: DeferAddMetadata = (deferFn, metadatas) => {
     return { id };
   };
 
+  deferFnWithMetadata.__fn = deferFn.__fn;
+  deferFnWithMetadata.__metadata = deferFn.__metadata;
   deferFnWithMetadata.__execOptions = {
     ...deferFn.__execOptions,
     metadatas,

--- a/tests/addMetadata.spec.ts
+++ b/tests/addMetadata.spec.ts
@@ -1,0 +1,50 @@
+import { defer, delay, addMetadata, configure } from "../src";
+import { HTTPClient, makeHTTPClient } from "../src/httpClient";
+
+jest.mock("../src/httpClient");
+
+describe("addMetadata()", () => {
+  describe("when Defer is active (`DEFER_TOKEN` is set)", () => {
+    describe("with successful API responses", () => {
+      let httpClient: HTTPClient | undefined;
+
+      beforeAll(() => {
+        httpClient = jest.fn().mockImplementationOnce(async () => {
+          return { id: "1" } as any;
+        });
+        jest.mocked(makeHTTPClient).mockImplementationOnce(() => httpClient!);
+        configure({ accessToken: "test" });
+      });
+
+      it("should throw if arguments are not serializable", async () => {
+        const myFunction = jest.fn(async function testFn(_str: bigint) {});
+        const deferred = defer(myFunction);
+        const defferedWithMetadata = addMetadata(deferred, { foo: "bar" });
+        await expect(defferedWithMetadata(2n)).rejects.toThrow(
+          "cannot serialize argument: Do not know how to serialize a BigInt"
+        );
+
+        expect(myFunction).not.toHaveBeenCalled();
+      });
+
+      it("should NOT call the wrapped function and return execution ID", async () => {
+        const myFunction = jest.fn(async (_str: string) => {});
+        const deferred = defer(myFunction);
+        const delayed = delay(deferred, new Date("2023-01-01"));
+        const defferedWithMetadata = addMetadata(delayed, {
+          foo: "bar",
+          foo2: "bar2",
+        });
+
+        const result = await defferedWithMetadata("");
+        expect(result).toEqual({ id: "1" });
+        expect(myFunction).not.toHaveBeenCalled();
+        expect(httpClient).toHaveBeenCalledWith(
+          "POST",
+          "/api/v1/enqueue",
+          '{"name":"mockConstructor","arguments":[""],"schedule_for":"2023-01-01T00:00:00.000Z","metadata":{"foo":"bar","foo2":"bar2"}}'
+        );
+      });
+    });
+  });
+});

--- a/tests/delay.spec.ts
+++ b/tests/delay.spec.ts
@@ -38,7 +38,7 @@ describe("delay()", () => {
         expect(httpClient).toHaveBeenCalledWith(
           "POST",
           "/api/v1/enqueue",
-          '{"name":"mockConstructor","arguments":[""],"schedule_for":"2023-01-01T00:00:00.000Z"}'
+          '{"name":"mockConstructor","arguments":[""],"schedule_for":"2023-01-01T00:00:00.000Z","metadata":{}}'
         );
       });
     });


### PR DESCRIPTION
### TODO
- rename ? metadata namespace is used for retry and version etc
- [x] make `addMetadata` really add and not replace
- [x] Fix tests