### PR TITLE
feat: introduce `timeout` beta support

### DIFF
--- a/.changeset/spicy-crabs-drop.md
+++ b/.changeset/spicy-crabs-drop.md
@@ -12,8 +12,8 @@ const importContacts = (companyId: string, contacts: Contact[]) => {
 };
 
 export default defer(importContacts, {
-  timeout: 10000, // timeout after 10secs
+  timeout: 10, // timeout after 10secs
 });
 ```
 
-BREAKING CHANGE: `timeout` has a default value to 30min. Users having executions going over this limit can override it with `{ timeout: false }`
+BREAKING CHANGE: `timeout` has a default value to 30min. Users having executions going over this limit can override it with a higher value `{ timeout: 3600 }`

--- a/.changeset/spicy-crabs-drop.md
+++ b/.changeset/spicy-crabs-drop.md
@@ -1,0 +1,19 @@
+---
+"@defer/client": minor
+---
+
+Introducing `timeout` beta support
+
+`defer()` exposes a new `timeout` configuration:
+
+```ts
+const importContacts = (companyId: string, contacts: Contact[]) => {
+  //  ...
+};
+
+export default defer(importContacts, {
+  timeout: 10000, // timeout after 10secs
+});
+```
+
+BREAKING CHANGE: `timeout` has a default value to 30min. Users having executions going over this limit can override it with `{ timeout: false }`

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,6 +15,7 @@ module.exports = {
       ],
       rules: {
         "@typescript-eslint/ban-types": 1,
+        "@typescript-eslint/no-explicit-any": 0,
       },
     },
   ],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
-export const INTERNAL_VERSION = 4;
+export const INTERNAL_VERSION = 5;
 export const RETRY_MAX_ATTEMPTS_PLACEHOLDER = 13;
+export const EXECUTION_DEFAULT_TIMEMOUT = 1800;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -45,3 +45,10 @@ export class APIError extends ClientError {
     Object.setPrototypeOf(this, APIError.prototype);
   }
 }
+
+export class DeferExecutionTimeoutError extends ClientError {
+  constructor(msg: string) {
+    super(msg);
+    Object.setPrototypeOf(this, APIError.prototype);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,7 +220,10 @@ export const defer: Defer = (fn, options) => {
     return { id };
   };
 
-  ret.__fn = timeoutable(fn, options?.timeout || EXECUTION_DEFAULT_TIMEMOUT);
+  ret.__fn =
+    typeof options?.timeout === "boolean" && options?.timeout === false
+      ? fn
+      : timeoutable(fn, options?.timeout || EXECUTION_DEFAULT_TIMEMOUT);
 
   const retryPolicy: RetryPolicy = defaultRetryPolicy();
   switch (typeof options?.retry) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,10 +220,7 @@ export const defer: Defer = (fn, options) => {
     return { id };
   };
 
-  ret.__fn =
-    typeof options?.timeout === "boolean" && options?.timeout === false
-      ? fn
-      : timeoutable(fn, options?.timeout || EXECUTION_DEFAULT_TIMEMOUT);
+  ret.__fn = timeoutable(fn, options?.timeout || EXECUTION_DEFAULT_TIMEMOUT);
 
   const retryPolicy: RetryPolicy = defaultRetryPolicy();
   switch (typeof options?.retry) {

--- a/src/timeoutable.ts
+++ b/src/timeoutable.ts
@@ -1,0 +1,32 @@
+import { DeferExecutionTimeoutError } from "./errors.js";
+
+export const timeoutable = <
+  F extends (...args: any | undefined) => Promise<any>
+>(
+  fn: F,
+  timeout: number
+): F => {
+  return ((...args: Parameters<F>) => {
+    return new Promise((resolve, reject) => {
+      let hasExecuted = false;
+
+      const timeoutId = setTimeout(() => {
+        if (!hasExecuted) {
+          reject(
+            new DeferExecutionTimeoutError(
+              `${fn.name} timeout after ${timeout}secs`
+            )
+          );
+        }
+      }, timeout) as unknown as number;
+
+      // @ts-expect-error to solve
+      fn(...args)
+        .then(resolve, reject)
+        .finally(() => {
+          hasExecuted = true;
+          clearTimeout(timeoutId);
+        });
+    });
+  }) as F;
+};


### PR DESCRIPTION


`defer()` exposes a new `timeout` configuration:

```ts
const importContacts = (companyId: string, contacts: Contact[]) => {
  //  ...
};

export default defer(importContacts, {
  timeout: 10000, // timeout after 10secs
});
```

BREAKING CHANGE: `timeout` has a default value to 30min. Users having executions going over this limit can override it with `{ timeout: false }`