### PR TITLE
Bun support: Use crypto rather than URL/Blob API for generating random UUID 

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 // Although the function implementation may not be completely secure,
 // it is suitable for local use.
 export function randomUUID() {
-  return URL.createObjectURL(new Blob([])).slice(-36);
+  return crypto.randomUUID();
 }
 
 export function debug(...args: any) {


### PR DESCRIPTION
Solves this issue: https://github.com/defer-run/defer.client/issues/99