### PR TITLE
Add support for `concurrency` option when running locally

### DIFF
--- a/src/local.ts
+++ b/src/local.ts
@@ -1,0 +1,76 @@
+import { ExecutionState, FetchExecutionResponse } from "./client.js";
+import { DeferError } from "./errors.js";
+import {
+  DeferredFunction,
+  __database,
+  DeferableFunction,
+  Manifest,
+} from "./index";
+import { Queue } from "./queue.js";
+
+type Invocation<F extends DeferableFunction> = {
+  id: string;
+  func: DeferredFunction<F>
+  args: any
+  oncomplete: ((result: FetchExecutionResponse<any>) => void) | undefined
+};
+type FunctionConfiguration<F extends DeferableFunction> = Manifest & {
+  queue: Queue<Invocation<F>>;
+};
+const fns: Record<string, FunctionConfiguration<any>> = {};
+
+export function setupFn<F extends DeferableFunction>(metadata: Manifest) {
+  fns[metadata.id] = {
+    ...metadata,
+    queue: new Queue<Invocation<F>>(invoke, metadata.concurrency),
+  };
+}
+
+export function execLocally<F extends DeferableFunction>(
+  id: string,
+  func: DeferredFunction<F>,
+  args: any
+): Promise<FetchExecutionResponse<any>> {
+  return new Promise(resolve => {
+    fns[func.__metadata.id]!.queue.push({
+      id,
+      func,
+      args,
+      oncomplete: resolve
+    });
+  })
+}
+
+async function invoke(invocation: Invocation<any>) {
+    __database.set(invocation.id, { id: invocation.id, state: "started" });
+    let state: ExecutionState = "succeed";
+    let originalResult: any;
+    try {
+      originalResult = await invocation.func.__fn(...invocation.args);
+    } catch (error) {
+      const e = error as Error;
+      state = "failed";
+      originalResult = {
+        name: e.name,
+        message: e.message,
+        cause: e.cause,
+        stack: e.stack,
+      };
+
+      console.error('Error in deferred function ' + invocation.func.__fn.name + ' (invocation ' + invocation.id + '):\n', e)
+    }
+  
+    let result: any;
+    try {
+      result = JSON.parse(JSON.stringify(originalResult || ""));
+    } catch (error) {
+      const e = error as Error;
+      throw new DeferError(`cannot serialize function return: ${e.message}`);
+    }
+  
+    const response = { id: invocation.id, state, result }
+    __database.set(invocation.id, response);
+
+    invocation.oncomplete?.(response)
+  
+}

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,0 +1,33 @@
+import { Concurrency } from ".";
+
+export class Queue<T> extends Array<T> {
+  private running = 0;
+
+  constructor(public invoker: (item: T) => Promise<void>, public concurrency?: Concurrency) {
+    super();
+    Object.setPrototypeOf(this, Queue.prototype)
+  }
+
+  override push(...items: T[]): number {
+    const len = super.push(...items);
+    this.next();
+    return len;
+  }
+
+  private next() {
+    if (!this.concurrency || this.running < this.concurrency) {
+      this.dequeue();
+    }
+  }
+
+  private dequeue() {
+    const item = this.shift();
+    if (item) {
+      ++this.running;
+      this.invoker(item).finally(() => {
+        --this.running;
+        this.next();
+      });
+    }
+  }
+}


### PR DESCRIPTION
Fixes #106 by adding an in-memory queue for function invocations.