### PR TITLE
Fix execution state bad values

### DIFF
--- a/.changeset/funny-waves-buy.md
+++ b/.changeset/funny-waves-buy.md
@@ -1,0 +1,5 @@
+---
+"@defer/client": minor
+---
+
+Fix execution state bad values

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,9 +25,9 @@ export type ExecutionState =
   | "succeed"
   | "failed"
   | "cancelled"
-  | "cancelling"
   | "aborting"
-  | "aborted";
+  | "aborted"
+  | "discarded";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface FetchExecutionResponse<R = any> {


### PR DESCRIPTION
- Missing `discarded` value.
- `cancelling` value was never returned by our API.