### PR TITLE
fix(backend/local): fix enqueue passing wrapped fn name to `functionIdMapping.set()`

### DIFF
--- a/.changeset/cold-candles-film.md
+++ b/.changeset/cold-candles-film.md
@@ -1,0 +1,5 @@
+---
+"@defer/client": minor
+---
+
+Fix local concurrency applied globally

--- a/src/backend/local.ts
+++ b/src/backend/local.ts
@@ -341,10 +341,10 @@ export async function enqueue<F extends DeferableFunction>(
   discardAfter: Date | undefined,
   metadata: { [key: string]: string } | undefined,
 ): Promise<EnqueueResult> {
-  let functionId = functionIdMapping.get(func.name);
+  let functionId = functionIdMapping.get(func.__metadata.name);
   if (functionId === undefined) {
     functionId = randomUUID();
-    functionIdMapping.set(func.name, functionId);
+    functionIdMapping.set(func.__metadata.name, functionId);
   }
 
   const now = new Date();
@@ -352,7 +352,7 @@ export async function enqueue<F extends DeferableFunction>(
     id: randomUUID(),
     state: "created",
     functionId: functionId,
-    functionName: func.__fn.name,
+    functionName: func.__metadata.name,
     func,
     args: stringify(args),
     metadata: metadata || {},


### PR DESCRIPTION
Local backend's `enqueue` was passing the wrapped function's name (`defer()`: `"wrapped"`) to `functionIdMapping` resulting in a globally applied concurrency, example here of a `functionIdMapping` local repro with 3 different functions:

```
Map(1) { 'wrapped' => '4733ec2f-d20c-4043-9ee7-2e58bbf904ac' }
```