### PR TITLE
typescript update for the `DeferredFunction`

### DIFF
--- a/.changeset/old-doors-explain.md
+++ b/.changeset/old-doors-explain.md
@@ -1,0 +1,5 @@
+---
+"@defer/client": patch
+---
+
+update type definition for `DeferableFunction`

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export interface RetryPolicy {
   maxInterval: number;
 }
 
-export type DeferableFunction = (...args: any) => Promise<any>;
+export type DeferableFunction = (...args: any[]) => Promise<any>;
 
 export interface ExecutionOptions {
   delay?: Duration | Date;


### PR DESCRIPTION
Hello,

This PR should is purely an update to the TypeScript and should have no behavior change within the javascript. 

The motivation for the PR is that type definition of `DeferableFunction` is not correct enough to [make a wrapper ](https://gist.github.com/phil-loops/19769bc8327c0d0fd5fd2784b6e10726)for the `defer` function. 

The heart of the change is:
```ts
 -- export type DeferableFunction = (...args: any) => Promise<any>;
 ++ export type DeferableFunction = (...args: any[]) => Promise<any>;
```

I created a [playground demo](https://www.typescriptlang.org/play?noFallthroughCasesInSwitch=false&suppressImplicitAnyIndexErrors=true#code/LAKFBcE8AcFMAIAisBmsBOBDARgG1gGICuAdgMbgCWA9iQOqXgAWAgiZC+lpPALzwAKAHQjM6AOYBnAFzxM7ANoBdAJR8AfPAAK6agFtKk2AB55kdQG5QZWpPDxousrEmSGzNhy6ZIs5Giw8QlIKGnpGVnZObj45SUhyQREhMSk1Xk0Ab1B4eBsSO3hsaTt0ShJxWNTJIXwK5hz4AHom3NyAPXhJcuci+EM86i5YClwecoD0WAATOLl4EiI9bAwAGnhpkdwxcsrGOcwu8DKK-skHXSC9TCoyUABfKzBnqDgkVAwcfGJyKlp3SI8fjCUQSGRydjpTQ6fSGExmSzWWz2RzUZyuAGePwfQLfEJ-cIedhVeKJEEpMFQ+DZEC5fKFYqlXZVMG1WD1JiNFpteCdJgYWDrapsjlnIqwZkTDBTWaYc5mdaSajwZgCsUkZU2PTQSjbAlnSREBD8qYPJ6gIA) of this issue.

